### PR TITLE
Scaling: Dont stretch output and add integer scaling

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -62,6 +62,7 @@ byte anydirty;
 
 static int scale = 1;
 static int density = 0;
+static int integer_scale = 0;
 
 static int rgb332;
 
@@ -82,6 +83,7 @@ static int filter[3][4] = {
 rcvar_t lcd_exports[] =
 {
 	RCV_INT("scale", &scale),
+	RCV_INT("integer_scale", &integer_scale),
 	RCV_INT("density", &density),
 	RCV_INT("palid", &pal_id),
 	RCV_BOOL("rgb332", &rgb332),

--- a/src/main.c
+++ b/src/main.c
@@ -51,7 +51,8 @@ static char *defaultconfig[] =
 	"bind ins savestate",
 	"bind del loadstate",
 	"set scale 2",
-	"set density 4"
+	"set density 4",
+	"set integer_scale 0",
 	"source gnuboy.rc",
 	"set filterdmg 0",
 	//"set palid 1",

--- a/sys/sdl2/sdl-video.c
+++ b/sys/sdl2/sdl-video.c
@@ -76,6 +76,17 @@ void vid_init()
 			renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
 		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, vmode[0], vmode[1]);
+
+		SDL_RenderSetLogicalSize(renderer, vmode[0], vmode[1]);
+		int integer_scale = rc_getint("integer_scale");
+		if (integer_scale)
+		{
+			int window_width, window_height, render_width, render_height;
+			SDL_GetRendererOutputSize(renderer, &window_width, &window_height);
+			SDL_RenderGetLogicalSize(renderer, &render_width, &render_height);
+			SDL_bool makes_sense = (window_width >= render_width && window_height >= render_height);
+			SDL_RenderSetIntegerScale(renderer, makes_sense);
+		}
 	}
 
 	fb.w = vmode[0];


### PR DESCRIPTION
Prevent stretching of the texture if the window size isn't the correct aspect ratio. 

This also adds the option to enable 'integer scaling' meaning it will maintain aspect ratio and only stretch to multiples of the lcd screen.

Before:
![image](https://user-images.githubusercontent.com/21236406/113460632-f863e680-9460-11eb-8f60-d5b875db083f.png)

After:
![image](https://user-images.githubusercontent.com/21236406/113460636-fa2daa00-9460-11eb-9412-e1be28e10ba8.png)

Integer scale off:
![image](https://user-images.githubusercontent.com/21236406/113461971-5c3cde00-9466-11eb-8d75-2cca21d82326.png)

Integer scale on:
![image](https://user-images.githubusercontent.com/21236406/113461979-6068fb80-9466-11eb-80b1-898cb86dbaec.png)

