### PR TITLE
Fix compilation error if not using sound

### DIFF
--- a/sys/sdl2/sdl-audio.c
+++ b/sys/sdl2/sdl-audio.c
@@ -31,7 +31,9 @@ static volatile int audio_done;
 
 rcvar_t pcm_exports[] =
 	{
+#ifdef SOUND
 		RCV_BOOL("sound", &sound),
+#endif
 		RCV_INT("stereo", &stereo),
 		RCV_INT("samplerate", &samplerate),
 		RCV_END};


### PR DESCRIPTION
Was getting `sdl-audio.c:35:22: error: use of undeclared identifier 'sound';`