### PR TITLE
Fix sourcing RC files on windows

### DIFF
--- a/lib/xz/xz.h
+++ b/lib/xz/xz.h
@@ -19,6 +19,8 @@
 #	include <stdint.h>
 #endif
 
+#include "xz_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/windows/windows.c
+++ b/sys/windows/windows.c
@@ -12,6 +12,7 @@
 char *strdup();
 
 #include <SDL2/SDL.h>
+#include "rc.h"
 
 void *sys_timer()
 {
@@ -50,25 +51,13 @@ void sys_sanitize(char *s)
 
 void sys_initpath(char *exe)
 {
-	char *buf, *home, *p;
+	char *buf = ".";
 
-	home = strdup(exe);
-	sys_sanitize(home);
-	p = strrchr(home, '/');
-	if (p) *p = 0;
-	else
-	{
-		buf = ".";
+	if (rc_getstr("rcpath") == NULL)
 		rc_setvar("rcpath", 1, &buf);
+
+	if (rc_getstr("savedir") == NULL)
 		rc_setvar("savedir", 1, &buf);
-		return;
-	}
-	buf = malloc(strlen(home) + 8);
-	sprintf(buf, ".;%s/", home);
-	rc_setvar("rcpath", 1, &buf);
-	sprintf(buf, ".", home);
-	rc_setvar("savedir", 1, &buf);
-	free(buf);
 }
 
 void sys_checkdir(char *path, int wr)


### PR DESCRIPTION
I just cleaned up tthe `sys_initpath()`  function. It now just sets `savedir` and `rcpath` to ".", which is the currently working directory https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats.

If you happen to set them in the  `gnuboy.rc` file it uses those instead.
I also just fixed a warning in the xz lib not including the user config file.

Tested in Win10, mingw build.