### PR TITLE
Fix possible causes of emulation hangs

### DIFF
--- a/sys/nix/nix.c
+++ b/sys/nix/nix.c
@@ -35,8 +35,6 @@ int sys_elapsed(Uint32 *cl)
 	Uint32 now;
 	Uint32 usecs;
 
-	if(*cl <= 0) return;
-
 	now = SDL_GetTicks() * 1000;
 	usecs = now - *cl;
 	*cl = now;
@@ -45,6 +43,8 @@ int sys_elapsed(Uint32 *cl)
 
 void sys_sleep(int us)
 {
+	if(us <= 0) return;
+	
 	SDL_Delay(us/1000);
 }
 

--- a/sys/nix/nix.c
+++ b/sys/nix/nix.c
@@ -35,6 +35,8 @@ int sys_elapsed(Uint32 *cl)
 	Uint32 now;
 	Uint32 usecs;
 
+	if(*cl <= 0) return;
+
 	now = SDL_GetTicks() * 1000;
 	usecs = now - *cl;
 	*cl = now;

--- a/sys/sdl2/sdl-audio.c
+++ b/sys/sdl2/sdl-audio.c
@@ -21,6 +21,10 @@
 
 struct pcm pcm;
 
+#ifndef SOUND
+#define SILENT
+#endif
+
 #ifdef SILENT
 static int sound = 0;
 #endif

--- a/sys/sdl2/sdl-audio.c
+++ b/sys/sdl2/sdl-audio.c
@@ -90,8 +90,14 @@ int pcm_submit()
 		SDL_Delay(4);
 	audio_done = 0;
 	pcm.pos = 0;
-#endif
+
 	return 1;
+#endif
+
+#ifdef SILENT
+	return 0;
+#endif
+	
 }
 
 void pcm_close()

--- a/sys/windows/windows.c
+++ b/sys/windows/windows.c
@@ -28,8 +28,6 @@ int sys_elapsed(Uint32 *cl)
 	Uint32 now;
 	Uint32 usecs;
 
-	if(*cl <= 0) return;
-
 	now = SDL_GetTicks() * 1000;
 	usecs = now - *cl;
 	*cl = now;
@@ -38,6 +36,8 @@ int sys_elapsed(Uint32 *cl)
 
 void sys_sleep(int us)
 {
+	if(us <= 0) return;
+
 	/* dbk: for some reason 2000 works..
 	   maybe its just compensation for the time it takes for SDL_Delay to
 	   execute, or maybe sys_timer is too slow */

--- a/sys/windows/windows.c
+++ b/sys/windows/windows.c
@@ -28,6 +28,8 @@ int sys_elapsed(Uint32 *cl)
 	Uint32 now;
 	Uint32 usecs;
 
+	if(*cl <= 0) return;
+
 	now = SDL_GetTicks() * 1000;
 	usecs = now - *cl;
 	*cl = now;


### PR DESCRIPTION
I still can get a hang when resizing/moving the window when the binary has been compiled with -DSILENT. Hopefully this is a step in the right direction for fixing these hangs...